### PR TITLE
fix: Cargo test args being parsed breaks test

### DIFF
--- a/tests/jwt-cli.rs
+++ b/tests/jwt-cli.rs
@@ -11,6 +11,10 @@ mod tests {
     use jsonwebtoken::{Algorithm, Header, TokenData};
     use serde_json::{from_value, json};
 
+    fn empty_args() -> impl IntoIterator<Item = String> {
+        std::iter::empty()
+    }
+
     #[test]
     fn payload_item_from_string() {
         let string = Some("this=that");
@@ -54,7 +58,7 @@ mod tests {
 
     #[test]
     fn payload_from_payload_items() {
-        let _matcher = config_options().get_matches();
+        let _matcher = config_options().get_matches_from_safe(empty_args());
         let payload_item_one = PayloadItem::from_string(Some("this=that")).unwrap();
         let payload_item_two = PayloadItem::from_string(Some("full=yolo")).unwrap();
         let payloads = vec![payload_item_one, payload_item_two];


### PR DESCRIPTION
<!--
Hey, thanks for submitting a pull request! I really appreciate it.

Here's a list of things to check before getting a review. I look forward to reviewing it!
-->

### Summary
Passing args to `cargo test` such as `cargo test -- --test-threads=1` causes tests to fail since the `cargo` arguments are being parsed by the test. This fixes that by explicity using the `get_matches_from_safe` function even when there are no arguments used in the test.

### Preflight checklist
- [x] Code formatted with rustfmt
- [x] Relevant tests added
- [x] Any new documentation added
