### PR TITLE
Default decoding to JSON if not in a TTY

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,7 @@ fn config_options<'a, 'b>() -> App<'a, 'b> {
                         .default_value(""),
                 ).arg(
                     Arg::with_name("json")
-                        .help("render decoded JWT as JSON")
+                        .help("render decoded JWT as JSON (default if stdout is not a TTY)")
                         .long("json")
                         .short("j"),
                 ),
@@ -473,7 +473,7 @@ fn decode_token(
             None => dangerous_insecure_decode::<Payload>(&jwt),
         },
         dangerous_insecure_decode::<Payload>(&jwt),
-        if matches.is_present("json") {
+        if matches.is_present("json") || !atty::is(Stream::Stdout) {
             OutputFormat::JSON
         } else {
             OutputFormat::Text


### PR DESCRIPTION


<!--
Hey, thanks for submitting a pull request! I really appreciate it.

Here's a list of things to check before getting a review. I look forward to reviewing it!
-->

### Summary
Use JSON output if not in a tty. This makes jwt-cli cleaner to use in pipelines. For instance: `get-jwt-from-api | jwt decode - | bat -l json`. I did not add a test for this functionality, since I couldn't find a way to override `isatty` within the testing framework. 

It may also be nice to attempt to read the JWT from stdin if it isn't provided as an argument, but that is for another PR. 

### Preflight checklist
- [X] Code formatted with rustfmt
- [ ] Relevant tests added
- [X] Any new documentation added
