### PR TITLE
allow files to be used as HMAC secrets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -324,7 +324,12 @@ fn slurp_file(file_name: &str) -> Vec<u8> {
 fn encoding_key_from_secret(alg: &Algorithm, secret_string: &str) -> JWTResult<EncodingKey> {
     match alg {
         Algorithm::HS256 | Algorithm::HS384 | Algorithm::HS512 => {
-            Ok(EncodingKey::from_secret(secret_string.as_bytes()))
+            if secret_string.starts_with('@') {
+                let secret = slurp_file(&secret_string.chars().skip(1).collect::<String>());
+                Ok(EncodingKey::from_secret(&secret))
+            } else {
+                Ok(EncodingKey::from_secret(secret_string.as_bytes()))
+            }
         }
         Algorithm::RS256 | Algorithm::RS384 | Algorithm::RS512 => {
             let secret = slurp_file(&secret_string.chars().skip(1).collect::<String>());


### PR DESCRIPTION
This PR resolves the issue I reported in #109, so that HMAC secrets can be read from a file. Previously, if one attempted to read from a file by passing `@filename` (as the --help text suggests), the literal string `@filename` was used as the secret instead.

As an aside, anyone who has used this tool with HMAC JWTs must have quite brute-forceable secrets, since they likely contain only printable characters.