### PR TITLE
Trim potential whitespace around jwt before decoding

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -464,7 +464,10 @@ fn decode_token(
 
             buffer
         })
-        .unwrap();
+        .unwrap()
+        .trim()
+        .to_owned();
+
     let secret_validator = create_validations(algorithm);
 
     (

--- a/tests/jwt-cli.rs
+++ b/tests/jwt-cli.rs
@@ -470,6 +470,21 @@ mod tests {
     }
 
     #[test]
+    fn decodes_a_token_with_leading_and_trailing_whitespace() {
+        let matches = config_options()
+            .get_matches_from_safe(vec![
+                "jwt",
+                "decode",
+                "    eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.SEQijh6tEuOOAAKpHPuKxgFqEvlTNP1jj4FUNoBwXaM ",
+            ])
+            .unwrap();
+        let decode_matches = matches.subcommand_matches("decode").unwrap();
+        let (result, _, _) = decode_token(&decode_matches);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn encodes_and_decodes_an_rsa_token_using_key_from_file() {
         let body: String = "{\"field\":\"value\"}".to_string();
         let encode_matcher = config_options()


### PR DESCRIPTION
### Summary

Given that JWTs are base64 encoded and can thus not have leading
or trailing whitespace, it is safe to trim the string before
decoding (e.g. the decoder on jwt.io appears to do the same). This
is mostly a convenience feature for people using jwt-cli like this:

    # pbpaste prints the text from the clipboard on macOS
    pbpaste | jwt decode -

When copying from UIs such the Fx developer tools it's not always
trivial to copy the value without any whitespace, and this change
avoids the extra step of having to remove that whitespace manually.
Of course e.g. piping through `xargs` would also be an option, but
is, in my opinion, very obscure especially when used in scripts.

### Preflight checklist

- [x] Code formatted with rustfmt
- [x] Relevant tests added
- [ ] Any new documentation added (unclear whether necessary)

PS: Thanks for writing this nice tool 👍🏼 🚀 