### PR TITLE
Add repository metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jwt-cli"
 description = "A super fast CLI tool to decode and encode JWTs built in Rust"
 version = "5.0.2"
+repository = "https://github.com/mike-engel/jwt-cli"
 authors = ["Mike Engel <mike@mike-engel.com>", "Corey McGregor <https://github.com/shousper>", "Aaron Schaef <https://github.com/atschaef>", "Hugh Simpson <https://github.com/hughsimpson>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### Summary

It was pretty hard to navigate to this repository after finding out about this package on [crates.io](https://crates.io/crates/jwt-cli/) since no metadata were given. This PR simply adds `repository` key to cargo manifest to associate the crates.io package with this repository.

### Preflight checklist
- [ ] Code formatted with rustfmt
- [ ] Relevant tests added
- [ ] Any new documentation added
