### PR TITLE
Adding `--date' argument to configure time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add Macports installation info #231
 - Remove Gofish installation info. See #228
 - Adds support for EdDSA algo
+- Added `--date` argument to change the display format of the timestamps
 
 # 5.0.3
 

--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -127,12 +127,6 @@ pub struct DecodeArgs {
     #[clap(default_missing_value = "UTC")]
     pub time_format: Option<TimeFormat>,
 
-    /// Display unix timestamps as ISO 8601 dates in UTC.
-    /// Use --date for finer control
-    #[clap(long = "iso8601")]
-    #[clap(value_parser)]
-    pub iso_dates: bool,
-
     /// The secret to validate the JWT with. Prefix with @ to read from a file or b64: to use base-64 encoded bytes
     #[clap(long = "secret", short = 'S')]
     #[clap(default_value = "")]

--- a/src/translators/decode.rs
+++ b/src/translators/decode.rs
@@ -127,7 +127,7 @@ pub fn decode_token(
 
     let token_data =
         decode::<Payload>(&jwt, &insecure_decoding_key, &insecure_validator).map(|mut token| {
-            if arguments.iso_dates || arguments.time_format.is_some() {
+            if arguments.time_format.is_some() {
                 token
                     .claims
                     .convert_timestamps(arguments.time_format.unwrap_or(super::TimeFormat::UTC));

--- a/src/translators/decode.rs
+++ b/src/translators/decode.rs
@@ -127,8 +127,10 @@ pub fn decode_token(
 
     let token_data =
         decode::<Payload>(&jwt, &insecure_decoding_key, &insecure_validator).map(|mut token| {
-            if arguments.iso_dates {
-                token.claims.convert_timestamps();
+            if arguments.iso_dates || arguments.time_format.is_some() {
+                token
+                    .claims
+                    .convert_timestamps(arguments.time_format.unwrap_or(super::TimeFormat::UTC));
             }
 
             token

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -657,7 +657,7 @@ mod tests {
     }
 
     #[test]
-    fn shows_timestamps_as_iso_dates() {
+    fn shows_timestamps_as_dates() {
         let exp = (Utc::now() + Duration::minutes(60)).timestamp();
         let nbf = Utc::now().timestamp();
         let encode_matcher = App::command()
@@ -680,7 +680,7 @@ mod tests {
                 "decode",
                 "-S",
                 "1234567890",
-                "--iso8601",
+                "--date",
                 &encoded_token,
             ])
             .unwrap();
@@ -804,7 +804,7 @@ mod tests {
     }
 
     #[test]
-    fn shows_timestamps_as_iso_dates_with_local_offset() {
+    fn shows_timestamps_as_dates_with_local_offset() {
         let exp = (Utc::now() + Duration::minutes(60)).timestamp();
         let nbf = Utc::now().timestamp();
         let encode_matcher = App::command()
@@ -857,7 +857,7 @@ mod tests {
     }
 
     #[test]
-    fn shows_timestamps_as_iso_dates_with_fixed_offset() {
+    fn shows_timestamps_as_dates_with_fixed_offset() {
         let exp = (Utc::now() + Duration::minutes(60)).timestamp();
         let nbf = Utc::now().timestamp();
         let encode_matcher = App::command()


### PR DESCRIPTION
### Summary
`--iso8601` was too hard for me to remember, and most often than not I want to see the time in my local timezone

### Preflight checklist
- [x] Code formatted with rustfmt
- [x] Relevant tests added
- [x] Any new documentation added
