### PR TITLE
feat: support '.json' or inline JWKS secret for jwt decoding

### DIFF
--- a/tests/pub_ecdsa_jwks.json
+++ b/tests/pub_ecdsa_jwks.json
@@ -1,0 +1,20 @@
+{
+  "keys": [
+    {
+      "use": "sig",
+      "kty": "EC",
+      "kid": "4h7wt2IHHu_RLR6OtlZjCe_mIt8xAReS0cDEwwWAeKU",
+      "crv": "P-256",
+      "x": "w7JAoU_gJbZJvV-zCOvU9yFJq0FNC_edCMRM78P8eQQ",
+      "y": "wQg1EytcsEmGrM70Gb53oluoDbVhCZ3Uq3hHMslHVb4"
+    },
+    {
+      "use": "enc",
+      "kty": "EC",
+      "kid": "4h7wt2IHHu_RLR6OtlZjCe_mIt8xAReS0cDEwwWAeKU",
+      "crv": "P-256",
+      "x": "w7JAoU_gJbZJvV-zCOvU9yFJq0FNC_edCMRM78P8eQQ",
+      "y": "wQg1EytcsEmGrM70Gb53oluoDbVhCZ3Uq3hHMslHVb4"
+    }
+  ]
+}

--- a/tests/pub_rsa_jwks.json
+++ b/tests/pub_rsa_jwks.json
@@ -1,0 +1,18 @@
+{
+  "keys": [
+    {
+      "use": "sig",
+      "kty": "RSA",
+      "kid": "2caFcPx-aXaC6SevhV79UDIrs8LgUok2xo0A6DJPqJo",
+      "n": "589r2P-JpeFPkH2T8-SBw7ttzHPPlVzqJwb_fcXJl8MGZ_7Jkt8k58Ukgp3cgRdChDNlnrFeXu1wSwU47Mf_o9bBLVQbNCJ7uL-vQYdFwzEipqHusywJ-Qm5qpJyWO5f2hXMHnomZ1KZW4isg7g1kvynUznlSwU25wNUvRurRImxigT2ohmZzHf37n51zyzci5JZxneOojcyfXdhDWtRGuSbREW3XZqKnJbUOK9HqosrgidbFZil3j2uf4br7DLtdlZMJ4JzTE_ZX273el_uv_XFg-OuHvgdBHtgzN9rkKapkPyUT0BsWfOPyjEtrjzdAAiFQfuwhwIWQPidzBUKtw",
+      "e": "AQAB"
+    },
+    {
+      "use": "enc",
+      "kty": "RSA",
+      "kid": "2caFcPx-aXaC6SevhV79UDIrs8LgUok2xo0A6DJPqJo",
+      "n": "589r2P-JpeFPkH2T8-SBw7ttzHPPlVzqJwb_fcXJl8MGZ_7Jkt8k58Ukgp3cgRdChDNlnrFeXu1wSwU47Mf_o9bBLVQbNCJ7uL-vQYdFwzEipqHusywJ-Qm5qpJyWO5f2hXMHnomZ1KZW4isg7g1kvynUznlSwU25wNUvRurRImxigT2ohmZzHf37n51zyzci5JZxneOojcyfXdhDWtRGuSbREW3XZqKnJbUOK9HqosrgidbFZil3j2uf4br7DLtdlZMJ4JzTE_ZX273el_uv_XFg-OuHvgdBHtgzN9rkKapkPyUT0BsWfOPyjEtrjzdAAiFQfuwhwIWQPidzBUKtw",
+      "e": "AQAB"
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Hey, thanks for submitting a pull request! I really appreciate it.

Here's a list of things to check before getting a review. I look forward to reviewing it!
-->

### Summary

Add support for JWKs secret for `jwt decode` for RSA and ES algorithms: 

* jwks can be passed via the `--secret` arg as  `.json` file

```bash
$ jwt decode --alg PS512 --secret @tests/pub_rsa_jwks.json --ignore-exp eyJ0eXAiOiJKV1QiLCJraWQiOiIyY2FGY1B4LWFYYUM2U2V2aFY3OVVESXJzOExnVW9rMnhvMEE2REpQcUpvIiwiYWxnIjoiUFM1MTIifQ.eyJmaWVsZCI6InZhbHVlIiwiZm9vIjoiYmFyIn0.O6r-pK6rDw0B
AadqJmBivtjk7ELU2pYpKIOU7qD8rah9mzwm29A0KoCoOabtQCkKNcmlcIKoC812UrP_nDZrAsC1msHPfjvkKlbkX63_zEcRCv-6VC1FMuek8yY6mhKiFaTISPDBfHCg_Fru2BDar_qBJn8rtct9y6cgDA5vLvL81jLmJrCXW8C5wP9xrkG5CUXdW9A8fqtxcEDoNZoYUoxCnLkh3Pz5IfAluepqDYjj6kvMWuAC88K1B_a1Z8QTqCuJZNIj_5g6UExmK7pqKvB5RZo62KGTw8wWqkmaPTf4TnD4n3Rb1K-MN1LTWMySqgPaw5YlSxT2eFwDvhRBnA

Token header
------------
{
  "typ": "JWT",
  "alg": "PS512",
  "kid": "2caFcPx-aXaC6SevhV79UDIrs8LgUok2xo0A6DJPqJo"
}

Token claims
------------
{
  "field": "value",
  "foo": "bar"
}
```

* Jwks can be passed as inline json via `--secret` arg: 

```bash
$ jwt decode --alg PS512 --secret "$(cat tests/pub_rsa_jwks.json)" --ignore-exp eyJ0eXAiOiJKV1QiLCJraWQiOiIyY2FGY1B4LWFYYUM2U2V2aFY3OVVESXJzOExnVW9rMnhvMEE2REpQcUpvIiwiYWxnIjoiUFM1MTIifQ.eyJmaWVsZCI6InZhbHVlIiwiZm9vIjoiYmFyIn0.O6r-pK6rDw0BAadqJmBivtjk7ELU2pYpKIOU7qD8rah9mzwm29A0KoCoOabtQCkKNcmlcIKoC812UrP_nDZrAsC1msHPfjvkKlbkX63_zEcRCv-6VC1FMuek8yY6mhKiFaTISPDBfHCg_Fru2BDar_qBJn8rtct9y6cgDA5vLvL81jLmJrCXW8C5wP9xrkG5CUXdW9A8fqtxcEDoNZoYUoxCnLkh3Pz5IfAluepqDYjj6kvMWuAC88K1B_a1Z8QTqCuJZNIj_5g6UExmK7pqKvB5RZo62KGTw8wWqkmaPTf4TnD4n3Rb1K-MN1LTWMySqgPaw5YlSxT2eFwDvhRBnA


Token header
------------
{
  "typ": "JWT",
  "alg": "PS512",
  "kid": "2caFcPx-aXaC6SevhV79UDIrs8LgUok2xo0A6DJPqJo"
}

Token claims
------------
{
  "field": "value",
  "foo": "bar"
}
```


> NOTE: a more practical use case for this inline json would be `$(curl https:/oauth.mydomain.com/.well-known/jwk.json)` to fetch the JWKS from a remote endpoint

####  Tests

I have added `tests/pub_rsa_jwks.json` and `tests/pub_ecdsa_jwks.json` which are  JWKS representation of `tests/private_rsa_key.der` and `tests/private_ecdsa_key.pk8`.

### Documentation

I guess this serves as doc?

### Preflight checklist
- [X] Code formatted rustfmt (`$ cargo fmt`)
- [X] Code linter check with clippy (`$ cargo clippy`)
- [X] Relevant tests added
- [X] Any new documentation added
