### PR TITLE
feat: add option keep-payload-order

### DIFF
--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -106,6 +106,11 @@ pub struct EncodeArgs {
     #[clap(long = "out", short = 'o')]
     #[clap(value_parser)]
     pub output_path: Option<PathBuf>,
+
+    /// prevent re-ordering of payload keys
+    #[clap(long)]
+    #[clap(value_parser)]
+    pub keep_payload_order: bool,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/src/translators/encode.rs
+++ b/src/translators/encode.rs
@@ -141,14 +141,11 @@ pub fn encode_token(arguments: &EncodeArgs) -> JWTResult<String> {
     maybe_payloads.append(&mut custom_payload.unwrap_or_default());
 
     let payloads = maybe_payloads.into_iter().flatten().collect();
-    let claims: Claims;
-    match arguments.keep_payload_order {
-        true => {
-            claims = Claims::OrderKept(payloads);
-        }
+    let claims = match arguments.keep_payload_order {
+        true => Claims::OrderKept(payloads),
         false => {
             let Payload(_claims) = Payload::from_payloads(payloads);
-            claims = Claims::Reordered(_claims);
+            Claims::Reordered(_claims)
         }
     };
 

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -1013,4 +1013,26 @@ mod tests {
 
         assert_eq!(decode_arguments.time_format, Some(TimeFormat::UTC));
     }
+
+    #[test]
+    fn keeps_payload_order() {
+        let encode_matcher = App::command()
+            .try_get_matches_from(vec![
+                "jwt",
+                "encode",
+                "--no-iat",
+                "--keep-payload-order",
+                "-S",
+                "1234567890",
+                "--payload",
+                "z=123",
+                "--payload",
+                "a=123",
+            ])
+            .unwrap();
+        let encode_matches = encode_matcher.subcommand_matches("encode").unwrap();
+        let encode_arguments = EncodeArgs::from_arg_matches(encode_matches).unwrap();
+        let encoded_token = encode_token(&encode_arguments).unwrap();
+        assert_eq!(encoded_token.as_str(), "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ6IjoxMjMsImEiOjEyM30.kvofE3KpCVQWpvrgx87u9LxjV-AK9bsVmS-Oddbz1Qg")
+    }
 }


### PR DESCRIPTION
<!--
Hey, thanks for submitting a pull request! I really appreciate it.

Here's a list of things to check before getting a review. I look forward to reviewing it!
-->

### Summary

Add option to keep payload order which can be helpful in reverse lookup situations.


### Preflight checklist
- [x] Code formatted rustfmt (`$ cargo fmt`)
- [x] Code linter check with clippy (`$ cargo clippy`)
- [x] Relevant tests added
- [x] Any new documentation added
