### PR TITLE
Verify exp independently of signature

### DIFF
--- a/src/translators/decode.rs
+++ b/src/translators/decode.rs
@@ -147,7 +147,7 @@ pub fn decode_token(
 
     insecure_validator.insecure_disable_signature_validation();
     insecure_validator.required_spec_claims = HashSet::new();
-    insecure_validator.validate_exp = false;
+    insecure_validator.validate_exp = !arguments.ignore_exp;
 
     let token_data = decode::<Payload>(&jwt, &insecure_decoding_key, &insecure_validator)
         .map_err(jsonwebtoken::errors::Error::into)


### PR DESCRIPTION
### Summary
Verify exp independently of signature. Checking the expiry of the token can be valuable regardless of verification of the signature. Implicitly verifying it unless `--ignore-exp` is specified seems to be the natural way of doing it in this tool.

My use case is this: I want to keep a locally cached JWT until it has expired, and only then mint a new one. The signature is implicitly trusted, I only have to check the expiry.

### Preflight checklist
- [x] Code formatted rustfmt (`$ cargo fmt`)
- [x] Code linter check with clippy (`$ cargo clippy`)
- [ ] Relevant tests added
- [ ] Any new documentation added

### Further notes
I'll be happy to write a test if the feature is accepted and a test is deemed necessary.

I have not added documentation. In fact, the way I read the current documentation leads me to believe that the functionality I have added is already the way it works.