### PR TITLE
Fix build on loongarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "clap_complete_nushell",
  "clap_generate",
  "jsonwebtoken",
+ "libc",
  "parse_duration",
  "serde",
  "serde_derive",
@@ -463,9 +464,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "link-cplusplus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ atty = "0.2"
 clap_generate = "3.0.3"
 clap_complete = "4.6.5"
 clap_complete_nushell = "4.6"
+libc = "0.2.180" # version with loongarch64 compatibility
 
 [dev-dependencies]
 tempdir = "0.3.7"


### PR DESCRIPTION
### Summary

Fixes compilation on loongarch64. The previous version of `libc` in the lock file is missing definitions for `loongarch64` architecture. This PR bumps `libc` to a compatible version.

### Preflight checklist

- [x] Code formatted rustfmt (`$ cargo fmt`) (code unchanged)
- [x] Code linter check with clippy (`$ cargo clippy`) (code unchanged)
- [x] Relevant tests added (code unchanged)
- [x] Any new documentation added
